### PR TITLE
build: update rust and ubi

### DIFF
--- a/Containerfile.loadtests
+++ b/Containerfile.loadtests
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:latest as builder
+FROM registry.access.redhat.com/ubi10/ubi:latest as builder
 
 RUN uname -m && \
     dnf install -y --setopt=install_weak_deps=False \
@@ -10,13 +10,13 @@ RUN uname -m && \
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain 1.92.0
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain 1.95.0
 
 RUN git clone https://github.com/guacsec/trustify-scale-testing --depth 1 && \
     cd trustify-scale-testing && \
     cargo build --release --bin loadtest
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest
 
 RUN microdnf install -y --setopt=install_weak_deps=0 \
         openssl && \

--- a/Containerfile.trustify
+++ b/Containerfile.trustify
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:latest AS builder
+FROM registry.access.redhat.com/ubi10/ubi:latest AS builder
 
 RUN uname -m && \
     dnf install -y --setopt=install_weak_deps=False \
@@ -10,7 +10,7 @@ RUN uname -m && \
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain 1.92.0
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain 1.95.0
 
 ARG rev
 RUN ["bash", "-c", "\
@@ -30,7 +30,7 @@ RUN ["bash", "-c", "\
 
 RUN cd trustify && cargo build --release --no-default-features --features bundled
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest
 
 RUN microdnf install -y --setopt=install_weak_deps=0 \
         openssl && \


### PR DESCRIPTION
* Updates rust to 1.95.0 to keep in sync with trustify-scale-testing and trustify
* Updates UBI from 9 to 10 to avoid an extra image pull and build like this:

```
registry.access.redhat.com/ubi10/ubi                                             latest      ee6c35741674  29 hours ago   220 MB
registry.access.redhat.com/ubi9/ubi                                              latest      0228cf554f51  33 hours ago   220 MB
registry.access.redhat.com/ubi9/ubi-minimal                                      latest      c5116dbb022c  33 hours ago   109 MB
```