### PR TITLE
perf: run ANALYZE only right after dump restoring

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -156,7 +156,7 @@ services:
         else
           echo "Importing dump"
           xzcat /cache/dump.sql.xz | psql -v ON_ERROR_STOP=1
-          echo "VACUUM ANALYZE; REINDEX database trustify;" | psql
+          echo "ANALYZE;" | psql
         fi
 
   trustify-migrate:


### PR DESCRIPTION
* The idea is to try to save a few minutes on each run
* We can see what happens if the situation worsens, and then we can reverse it. Although I am somewhat convinced

Details: https://gist.github.com/helio-frota/b4c4b508d53c199261e4f9db705c4bfc