### PR TITLE
chore: sync rust version with scale-tests

### DIFF
--- a/Containerfile.loadtests
+++ b/Containerfile.loadtests
@@ -10,7 +10,7 @@ RUN uname -m && \
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain 1.95.0
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain 1.96.1
 
 RUN git clone https://github.com/guacsec/trustify-scale-testing --depth 1 && \
     cd trustify-scale-testing && \

--- a/Containerfile.trustify
+++ b/Containerfile.trustify
@@ -10,7 +10,7 @@ RUN uname -m && \
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain 1.95.0
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain 1.96.1
 
 ARG rev
 RUN ["bash", "-c", "\


### PR DESCRIPTION
To avoid: 

```
error: rustc 1.95.0 is not supported by the following package:
  loadtest@0.1.0 requires rustc 1.96.1
```